### PR TITLE
add meta tags for title and description previews 

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1,7 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <title>DNS lookups!</title>
+      <title>a simple DNS lookup tool</title>
+      <meta name="title" content="a simple DNS lookup tool">
+      <meta name="description" content="make queries to 8.8.8.8">
+      <meta property="og:type" content="website">
+      <meta property="og:url" content="https://dns-lookup.jvns.ca">
+      <meta property="og:title" content="a simple DNS lookup tool">
+      <meta property="og:description" content="make queries to 8.8.8.8">
+      <meta property="twitter:url" content="https://dns-lookup.jvns.ca">
+      <meta property="twitter:title" content="a simple DNS lookup tool">
+      <meta property="twitter:description" content="make queries to 8.8.8.8">
       <meta charset="utf-8">
       <meta name="viewport" content="initial-scale=1, maximum-scale=1">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.3/tailwind.min.css">

--- a/site/trace.html
+++ b/site/trace.html
@@ -1,7 +1,16 @@
 <!DOCTYPE html>
 <html>
   <head>
-      <title>DNS lookups!</title>
+      <title>a simple DNS trace tool</title>
+      <meta name="title" content="a simple DNS trace tool">
+      <meta name="description" content="make queries to 8.8.8.8">
+      <meta property="og:type" content="website">
+      <meta property="og:url" content="https://dns-lookup.jvns.ca">
+      <meta property="og:title" content="a simple DNS lookup tool">
+      <meta property="og:description" content="make queries to 8.8.8.8">
+      <meta property="twitter:url" content="https://dns-lookup.jvns.ca">
+      <meta property="twitter:title" content="a simple DNS trace tool">
+      <meta property="twitter:description" content="make queries to 8.8.8.8">
       <meta charset="utf-8">
       <meta name="viewport" content="initial-scale=1, maximum-scale=1">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.3/tailwind.min.css">
@@ -34,7 +43,7 @@ input:checked + label:hover {
 
 <nav class="bg-purple-800 text-white w-full p-4 text-lg flex flex-row">
     <div class="w-1/2 sm:pl-8">
-        a simple DNS lookup tool
+        a simple DNS trace tool
     </div>
     <div class="w-1/2 text-right">
         <a href="https://github.com/jvns/dns-lookup">GitHub repository</a>

--- a/site/trace.html
+++ b/site/trace.html
@@ -3,14 +3,14 @@
   <head>
       <title>a simple DNS trace tool</title>
       <meta name="title" content="a simple DNS trace tool">
-      <meta name="description" content="make queries to 8.8.8.8">
+      <meta name="description" content="see how DNS queries get resolved behind the scenes">
       <meta property="og:type" content="website">
       <meta property="og:url" content="https://dns-lookup.jvns.ca">
-      <meta property="og:title" content="a simple DNS lookup tool">
-      <meta property="og:description" content="make queries to 8.8.8.8">
+      <meta property="og:title" content="a simple DNS trace tool">
+      <meta property="og:description" content="see how DNS queries get resolved behind the scenes">
       <meta property="twitter:url" content="https://dns-lookup.jvns.ca">
       <meta property="twitter:title" content="a simple DNS trace tool">
-      <meta property="twitter:description" content="make queries to 8.8.8.8">
+      <meta property="twitter:description" content="see how DNS queries get resolved behind the scenes">
       <meta charset="utf-8">
       <meta name="viewport" content="initial-scale=1, maximum-scale=1">
       <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.0.3/tailwind.min.css">


### PR DESCRIPTION
To allow for people to share https://dns-lookup.jvns.ca or https://dns-lookup.jvns.ca/trace.html and get some preview for each. Titles and descriptions follow the information for each tool on README.md